### PR TITLE
Improve mobile layout for brand list

### DIFF
--- a/public/html/auth/js/index.js
+++ b/public/html/auth/js/index.js
@@ -14,15 +14,11 @@ document.addEventListener("DOMContentLoaded", () => {
         html += `
         
           <div class="col-12 col-sm-6 col-md-4 mb-3 d-flex justify-content-center">
-            <a href="dashboard/modelo?id=${dado.marcascod}&marcascod=${dado.marcascod}" class="w-50">
+            <a href="dashboard/modelo?id=${dado.marcascod}&marcascod=${dado.marcascod}" class="w-100">
               <button class="btn btn-md btn-outline-dark w-100">${dado.marcasdes}</button>
             </a>
           </div>`;
 
-        // fecha/abre linha a cada 3 itens (12/4 = 3)
-        if ((i + 1) % 3 === 0 && i !== dados.length - 1) {
-          html += '</div><div class="row">';
-        }
       });
       html += "</div>";
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -14,15 +14,11 @@ document.addEventListener("DOMContentLoaded", () => {
         html += `
         
           <div class="col-6 col-sm-6 col-md-4 mb-3 d-flex justify-content-center">
-            <a href="modelo?id=${dado.marcascod}&marcascod=${dado.marcascod}" class="w-50">
+            <a href="modelo?id=${dado.marcascod}&marcascod=${dado.marcascod}" class="w-100">
               <button class="btn btn-md btn-outline-dark w-100">${dado.marcasdes}</button>
             </a>
           </div>`;
 
-        // fecha/abre linha a cada 3 itens (12/4 = 3)
-        if ((i + 1) % 3 === 0 && i !== dados.length - 1) {
-          html += '</div><div class="row">';
-        }
       });
       html += "</div>";
 


### PR DESCRIPTION
## Summary
- keep brand grid two-columns on phones by adjusting Bootstrap classes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686878928f80832c8b420c58001e0104