### PR TITLE
Add admin dropdown on profile

### DIFF
--- a/public/html/auth/js/perfil-gerenciamento.js
+++ b/public/html/auth/js/perfil-gerenciamento.js
@@ -1,0 +1,133 @@
+const params = new URLSearchParams(window.location.search);
+const id = params.get("id");
+let marcascod = null;
+let marcacodModelo = null;
+let tipo = null;
+let modelo = null;
+
+function carregarMarcas() {
+  fetch(`${BASE_URL}/marcas/`)
+    .then(res => res.json())
+    .then(marcas => {
+      const marcaSelectModelo = document.getElementById('painelMarca');
+      const marcaSelectPeca = document.getElementById('selectPainelMarca');
+      if (marcaSelectModelo) {
+        marcaSelectModelo.innerHTML = '<option value="">Selecione uma marca</option>';
+      }
+      if (marcaSelectPeca) {
+        marcaSelectPeca.innerHTML = '<option value="">Selecione a Marca</option>';
+      }
+      marcas.forEach(marca => {
+        const opt = `<option value="${marca.marcascod}"${id == marca.marcascod ? ' selected' : ''}>${marca.marcasdes}</option>`;
+        if (marcaSelectModelo) marcaSelectModelo.innerHTML += opt;
+        if (marcaSelectPeca) marcaSelectPeca.innerHTML += opt;
+      });
+      if (marcaSelectModelo) {
+        marcaSelectModelo.addEventListener('change', e => {
+          marcacodModelo = e.target.value;
+        });
+      }
+      if (marcaSelectPeca) {
+        marcaSelectPeca.addEventListener('change', e => {
+          marcascod = e.target.value;
+          carregarModelos(marcascod);
+        });
+      }
+    })
+    .catch(console.error);
+}
+
+function carregarModelos(codMarca) {
+  fetch(`${BASE_URL}/modelo/${codMarca}`)
+    .then(res => res.json())
+    .then(modelos => {
+      const holder = document.getElementById('selectPainelModelo');
+      if (!holder) return;
+      holder.innerHTML = '<option value="">Selecione o Modelo</option>';
+      modelos.forEach(mod => {
+        holder.innerHTML += `<option value="${mod.modcod}">${mod.moddes}</option>`;
+      });
+      holder.addEventListener('change', e => {
+        modelo = e.target.value;
+      });
+    })
+    .catch(console.error);
+}
+
+function carregarTipos() {
+  fetch(`${BASE_URL}/tipos/`)
+    .then(res => res.json())
+    .then(tipos => {
+      const holder = document.getElementById('selectPainelTipo');
+      if (!holder) return;
+      holder.innerHTML = '<option value="">Selecione o tipo</option>';
+      tipos.forEach(t => {
+        holder.innerHTML += `<option value="${t.tipocod}">${t.tipodes}</option>`;
+      });
+      holder.addEventListener('change', e => {
+        tipo = e.target.value;
+      });
+    })
+    .catch(console.error);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  carregarMarcas();
+  carregarTipos();
+});
+
+function postJSON(url, data) {
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  }).then(res => res.json());
+}
+
+const formMarca = document.getElementById('cadastrarPainelMarca');
+if (formMarca) {
+  formMarca.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(formMarca).entries());
+    postJSON(`${BASE_URL}/marcas`, data)
+      .then(() => { alert('Dados salvos com sucesso!'); location.reload(); })
+      .catch(err => { alert('Erro ao salvar os dados.'); console.error(err); });
+  });
+}
+
+const formModelo = document.getElementById('cadastrarPainelModelo');
+if (formModelo) {
+  formModelo.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(formModelo).entries());
+    data.modmarcascod = marcacodModelo;
+    postJSON(`${BASE_URL}/modelo`, data)
+      .then(() => { alert('Dados salvos com sucesso!'); location.reload(); })
+      .catch(err => { alert('Erro ao salvar os dados.'); console.error(err); });
+  });
+}
+
+const formTipo = document.getElementById('cadastrarPainelTipo');
+if (formTipo) {
+  formTipo.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(formTipo).entries());
+    postJSON(`${BASE_URL}/tipo`, data)
+      .then(() => { alert('Dados salvos com sucesso!'); location.reload(); })
+      .catch(err => { alert('Erro ao salvar os dados.'); console.error(err); });
+  });
+}
+
+const formPeca = document.getElementById('cadastrarPainelPeca');
+if (formPeca) {
+  formPeca.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(formPeca).entries());
+    data.promarcascod = marcascod;
+    data.promodcod = modelo;
+    data.protipocod = tipo;
+    postJSON(`${BASE_URL}/pro`, data)
+      .then(() => { alert('Dados salvos com sucesso!'); location.reload(); })
+      .catch(err => { alert('Erro ao salvar os dados.'); console.error(err); });
+  });
+}

--- a/public/html/auth/perfil.html
+++ b/public/html/auth/perfil.html
@@ -13,8 +13,10 @@
             background-color: #f8f9fa;
             min-height: 100vh;
             display: flex;
+            flex-direction: column;
             align-items: center;
-            justify-content: center;
+            justify-content: flex-start;
+            padding-top: 40px;
         }
         .perfil-container {
             max-width: 400px;
@@ -55,9 +57,107 @@
             <button type="submit" class="btn btn-primary">Salvar</button>
         </form>
     </div>
+
+    <div class="container mt-5">
+        <div class="card shadow-sm mb-4">
+            <div class="card-body">
+                <h4 class="card-title mb-4 text-primary font-weight-bold">Gerenciamento</h4>
+                <div class="row">
+                    <!-- Marca -->
+                    <div class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static">
+                        <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dropdownMarca" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Cadastrar Marca <i class="bi bi-plus-square"></i>
+                        </button>
+                        <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownMarca" style="min-width: 220px" onclick="event.stopPropagation();">
+                            <form id="cadastrarPainelMarca" class="form">
+                                <div class="form-group mb-2">
+                                    <input type="text" name="marcasdes" id="marcaDescricao" placeholder="Descrição da Marca" class="form-control" required />
+                                </div>
+                                <button type="submit" class="btn btn-success btn-block">Cadastrar</button>
+                            </form>
+                        </div>
+                    </div>
+                    <!-- Modelo -->
+                    <div class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static">
+                        <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dropdownModelo" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Cadastrar Modelo <i class="bi bi-plus-square"></i>
+                        </button>
+                        <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownModelo" style="min-width: 220px" onclick="event.stopPropagation();">
+                            <form id="cadastrarPainelModelo" class="form">
+                                <div class="form-group mb-2">
+                                    <input type="text" name="moddes" placeholder="Descrição do Modelo" class="form-control" required />
+                                </div>
+                                <div class="form-group mb-2">
+                                    <div class="custom-select-wrapper">
+                                        <select name="" id="painelMarca" class="form-control custom-select" required onclick="event.stopPropagation();">
+                                            <option value="">Selecione a Marca</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <button type="submit" class="btn btn-success btn-block">Cadastrar</button>
+                            </form>
+                        </div>
+                    </div>
+                    <!-- Tipo de Peça -->
+                    <div class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static">
+                        <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dropdownTipo" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Cadastrar Tipo de Peça <i class="bi bi-plus-square"></i>
+                        </button>
+                        <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownTipo" style="min-width: 220px" onclick="event.stopPropagation();">
+                            <form id="cadastrarPainelTipo" class="form">
+                                <div class="form-group mb-2">
+                                    <input type="text" name="tipodes" placeholder="Descrição do Tipo" class="form-control" required />
+                                </div>
+                                <button type="submit" class="btn btn-success btn-block">Cadastrar</button>
+                            </form>
+                        </div>
+                    </div>
+                    <!-- Peça -->
+                    <div class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static">
+                        <button class="btn btn-outline-primary btn-block dropdown-toggle" type="button" id="dropdownPeca" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Cadastrar Peça <i class="bi bi-plus-square"></i>
+                        </button>
+                        <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownPeca" style="min-width: 220px" onclick="event.stopPropagation();">
+                            <form id="cadastrarPainelPeca" class="form">
+                                <div class="form-group mb-2">
+                                    <input type="text" name="prodes" placeholder="Descrição da Peça" class="form-control" required />
+                                </div>
+                                <div class="form-group mb-2">
+                                    <input type="number" name="provl" placeholder="Valor R$" class="form-control" min="0" step="0.01" required />
+                                </div>
+                                <div class="form-group mb-2">
+                                    <div class="custom-select-wrapper">
+                                        <select name="" id="selectPainelMarca" class="form-control custom-select" required onclick="event.stopPropagation();">
+                                            <option value="">Selecione a Marca</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <div class="custom-select-wrapper">
+                                        <select name="" id="selectPainelModelo" class="form-control custom-select" required onclick="event.stopPropagation();">
+                                            <option value="">Selecione o Modelo</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-2">
+                                    <div class="custom-select-wrapper">
+                                        <select name="" id="selectPainelTipo" class="form-control custom-select" required onclick="event.stopPropagation();">
+                                            <option value="">Selecione o Tipo</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <button type="submit" class="btn btn-success btn-block">Cadastrar</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
     <script src="/config.js"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
     <script src="/html/auth/js/perfil.js"></script>
+    <script src="/html/auth/js/perfil-gerenciamento.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance profile layout for stacked sections
- embed management dropdowns (brand, model, type, part) on profile page
- add script to handle management forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68695c111be0832c834d7320eab248ab