### PR TITLE
Add password confirmation to profile page

### DIFF
--- a/public/html/auth/js/perfil.js
+++ b/public/html/auth/js/perfil.js
@@ -31,6 +31,12 @@ document.getElementById('formPerfil').addEventListener('submit', async (e) => {
   const usunome = document.getElementById('nome').value;
   const usuemail = document.getElementById('email').value;
   const ususenha = document.getElementById('senha').value;
+  const confirmSenha = document.getElementById('confirmarSenha').value;
+
+  if (ususenha !== confirmSenha) {
+    alert('As senhas não coincidem.');
+    return;
+  }
   try {
     const response = await fetch(`${BASE_URL}/auth/atualizarCadastro/${id}`, {
       method: 'PUT',
@@ -42,6 +48,7 @@ document.getElementById('formPerfil').addEventListener('submit', async (e) => {
     if (response.ok) {
       alert('Dados atualizados com sucesso!');
       document.getElementById('senha').value = '';
+      document.getElementById('confirmarSenha').value = '';
       window.location.href = `${BASE_URL}/painel`;
     } else {
       alert(data.error || data.mensagem || 'Erro ao atualizar dados');

--- a/public/html/auth/perfil.html
+++ b/public/html/auth/perfil.html
@@ -79,6 +79,10 @@
                 <label for="senha">Senha</label>
                 <input type="password" class="form-control" id="senha" placeholder="Nova senha" required>
             </div>
+            <div class="form-group">
+                <label for="confirmarSenha">Repetir Senha</label>
+                <input type="password" class="form-control" id="confirmarSenha" placeholder="Repita a nova senha" required>
+            </div>
             <button type="submit" class="btn btn-primary">Salvar</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- add repeat password field on profile
- validate password confirmation before update

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869b8aeb214832c8089eed63143c4f0