### PR TITLE
Improve painel UI with modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 💰 Sistema de pedidos simples
 
-Sistema web para pedidos simples com login e senha para administrador, onde o usuário comum pode selecionar os produtos, inserir no carrinho e finalizar enviando o pedido ao whatsapp e o administrador pode acessar o painal registrar os produtos e visualizar o dashboard.
+Sistema web para pedidos simples com login e senha para administrador, onde o usuário comum pode selecionar os produtos, inserir no carrinho e finalizar enviando o pedido ao WhatsApp. O administrador pode acessar o painel, registrar os produtos e visualizar o dashboard.
 
 ---
 ## 🛠️ Tecnologias Utilizadas

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sistama de pedidos",
   "main": "src/app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "Caio - Heitor - Alan",
   "license": "ISC",
@@ -19,5 +19,9 @@
     "middleware": "^1.0.0",
     "morgan": "^1.10.0",
     "pg": "^8.16.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "jsdom": "^24.0.0"
   }
 }

--- a/public/html/auth/admin/html/painel.html
+++ b/public/html/auth/admin/html/painel.html
@@ -157,41 +157,15 @@
                 </h4>
                 <div class="row">
                   <!-- Marca -->
-                  <div
-                    class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static"
-                  >
+                  <div class="col-12 col-sm-6 col-md-3 mb-3">
                     <button
-                      class="btn btn-outline-primary btn-block dropdown-toggle"
+                      class="btn btn-outline-primary btn-block"
                       type="button"
-                      id="dropdownMarca"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false"
+                      data-toggle="modal"
+                      data-target="#modalMarca"
                     >
                       Cadastrar Marca <i class="bi bi-plus-square"></i>
                     </button>
-                    <div
-                      class="dropdown-menu p-3 w-100 mt-2"
-                      aria-labelledby="dropdownMarca"
-                      style="min-width: 220px"
-                      onclick="event.stopPropagation();"
-                    >
-                      <form id="cadastrarPainelMarca" class="form">
-                        <div class="form-group mb-2">
-                          <input
-                            type="text"
-                            name="marcasdes"
-                            id="marcaDescricao"
-                            placeholder="Descrição da Marca"
-                            class="form-control"
-                            required
-                          />
-                        </div>
-                        <button type="submit" class="btn btn-success btn-block">
-                          Cadastrar
-                        </button>
-                      </form>
-                    </div>
                     <button
                       class="btn btn-outline-secondary btn-block mt-2"
                       type="button"
@@ -201,53 +175,15 @@
                     </button>
                   </div>
                   <!-- Modelo -->
-                  <div
-                    class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static"
-                  >
+                  <div class="col-12 col-sm-6 col-md-3 mb-3">
                     <button
-                      class="btn btn-outline-primary btn-block dropdown-toggle"
+                      class="btn btn-outline-primary btn-block"
                       type="button"
-                      id="dropdownModelo"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false"
+                      data-toggle="modal"
+                      data-target="#modalModelo"
                     >
                       Cadastrar Modelo <i class="bi bi-plus-square"></i>
                     </button>
-                    <div
-                      class="dropdown-menu p-3 w-100 mt-2"
-                      aria-labelledby="dropdownModelo"
-                      style="min-width: 220px"
-                      onclick="event.stopPropagation();"
-                    >
-                      <form id="cadastrarPainelModelo" class="form">
-                        <div class="form-group mb-2">
-                          <input
-                            type="text"
-                            name="moddes"
-                            placeholder="Descrição do Modelo"
-                            class="form-control"
-                            required
-                          />
-                        </div>
-                        <div class="form-group mb-2">
-                          <div class="custom-select-wrapper">
-                            <select
-                              name=""
-                              id="painelMarca"
-                              class="form-control custom-select"
-                              required
-                              onclick="event.stopPropagation();"
-                            >
-                              <option value="">Selecione a Marca</option>
-                            </select>
-                          </div>
-                        </div>
-                        <button type="submit" class="btn btn-success btn-block">
-                          Cadastrar
-                        </button>
-                      </form>
-                    </div>
                     <button
                       class="btn btn-outline-secondary btn-block mt-2"
                       type="button"
@@ -257,40 +193,15 @@
                     </button>
                   </div>
                   <!-- Tipo de Peça -->
-                  <div
-                    class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static"
-                  >
+                  <div class="col-12 col-sm-6 col-md-3 mb-3">
                     <button
-                      class="btn btn-outline-primary btn-block dropdown-toggle"
+                      class="btn btn-outline-primary btn-block"
                       type="button"
-                      id="dropdownTipo"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false"
+                      data-toggle="modal"
+                      data-target="#modalTipo"
                     >
                       Cadastrar Tipo de Peça <i class="bi bi-plus-square"></i>
                     </button>
-                    <div
-                      class="dropdown-menu p-3 w-100 mt-2"
-                      aria-labelledby="dropdownTipo"
-                      style="min-width: 220px"
-                      onclick="event.stopPropagation();"
-                    >
-                      <form id="cadastrarPainelTipo" class="form">
-                        <div class="form-group mb-2">
-                          <input
-                            type="text"
-                            name="tipodes"
-                            placeholder="Descrição do Tipo"
-                            class="form-control"
-                            required
-                          />
-                        </div>
-                        <button type="submit" class="btn btn-success btn-block">
-                          Cadastrar
-                        </button>
-                      </form>
-                    </div>
                     <button
                       class="btn btn-outline-secondary btn-block mt-2"
                       type="button"
@@ -300,90 +211,15 @@
                     </button>
                   </div>
                   <!-- Peça -->
-                  <div
-                    class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static"
-                  >
+                  <div class="col-12 col-sm-6 col-md-3 mb-3">
                     <button
-                      class="btn btn-outline-primary btn-block dropdown-toggle"
+                      class="btn btn-outline-primary btn-block"
                       type="button"
-                      id="dropdownPeca"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false"
+                      data-toggle="modal"
+                      data-target="#modalPeca"
                     >
                       Cadastrar Peça <i class="bi bi-plus-square"></i>
                     </button>
-                    <div
-                      class="dropdown-menu p-3 w-100 mt-2"
-                      aria-labelledby="dropdownPeca"
-                      style="min-width: 220px"
-                      onclick="event.stopPropagation();"
-                    >
-                      <form id="cadastrarPainelPeca" class="form">
-                        <div class="form-group mb-2">
-                          <input
-                            type="text"
-                            name="prodes"
-                            placeholder="Descrição da Peça"
-                            class="form-control"
-                            required
-                          />
-                        </div>
-                        <div class="form-group mb-2">
-                          <input
-                            type="number"
-                            name="provl"
-                            placeholder="Valor R$"
-                            class="form-control"
-                            min="0"
-                            step="0.01"
-                            required
-                          />
-                        </div>
-                        <div class="form-group mb-2">
-                          <div class="custom-select-wrapper">
-                            <select
-                              name=""
-                              id="selectPainelMarca"
-                              class="form-control custom-select"
-                              required
-                              onclick="event.stopPropagation();"
-                            >
-                              <option value="">Selecione a Marca</option>
-                            </select>
-                          </div>
-                        </div>
-                        <div class="form-group mb-2">
-                          <div class="custom-select-wrapper">
-                            <select
-                              name=""
-                              id="selectPainelModelo"
-                              class="form-control custom-select"
-                              required
-                              onclick="event.stopPropagation();"
-                            >
-                              <option value="">Selecione o Modelo</option>
-                            </select>
-                          </div>
-                        </div>
-                        <div class="form-group mb-2">
-                          <div class="custom-select-wrapper">
-                            <select
-                              name=""
-                              id="selectPainelTipo"
-                              class="form-control custom-select"
-                              required
-                              onclick="event.stopPropagation();"
-                            >
-                              <option value="">Selecione o Tipo</option>
-                            </select>
-                          </div>
-                        </div>
-                        <button type="submit" class="btn btn-success btn-block">
-                          Cadastrar
-                        </button>
-                      </form>
-                    </div>
                     <button
                       class="btn btn-outline-secondary btn-block mt-2"
                       type="button"
@@ -434,8 +270,8 @@
             </div>
           </div>
         </div>
-      </div>
-      <div class="container-float management-area" id="tabelaArea" style="display: none">
+  </div>
+  <div class="container-float management-area" id="tabelaArea" style="display: none">
         <div class="container-float bg-light">
           <table class="table" id="tabelaProdutos">
             <thead>
@@ -448,8 +284,128 @@
             <tbody id="corpoTabela"></tbody>
           </table>
         </div>
+  </div>
+  </main>
+
+  <!-- Modal Marca -->
+  <div class="modal fade" id="modalMarca" tabindex="-1" role="dialog" aria-labelledby="modalMarcaLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modalMarcaLabel">Cadastrar Marca</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <form id="cadastrarPainelMarca" class="form">
+            <div class="form-group">
+              <label for="marcaDescricao">Descrição da Marca</label>
+              <input type="text" name="marcasdes" id="marcaDescricao" class="form-control" required />
+            </div>
+            <button type="submit" class="btn btn-success">Cadastrar</button>
+          </form>
+        </div>
       </div>
-    </main>
+    </div>
+  </div>
+
+  <!-- Modal Modelo -->
+  <div class="modal fade" id="modalModelo" tabindex="-1" role="dialog" aria-labelledby="modalModeloLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modalModeloLabel">Cadastrar Modelo</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <form id="cadastrarPainelModelo" class="form">
+            <div class="form-group">
+              <label for="painelMarca">Marca</label>
+              <select id="painelMarca" class="form-control" required>
+                <option value="">Selecione a Marca</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Descrição do Modelo</label>
+              <input type="text" name="moddes" class="form-control" required />
+            </div>
+            <button type="submit" class="btn btn-success">Cadastrar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Tipo -->
+  <div class="modal fade" id="modalTipo" tabindex="-1" role="dialog" aria-labelledby="modalTipoLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modalTipoLabel">Cadastrar Tipo</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <form id="cadastrarPainelTipo" class="form">
+            <div class="form-group">
+              <label>Descrição do Tipo</label>
+              <input type="text" name="tipodes" class="form-control" required />
+            </div>
+            <button type="submit" class="btn btn-success">Cadastrar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Peça -->
+  <div class="modal fade" id="modalPeca" tabindex="-1" role="dialog" aria-labelledby="modalPecaLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modalPecaLabel">Cadastrar Peça</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <form id="cadastrarPainelPeca" class="form">
+            <div class="form-group">
+              <label>Descrição da Peça</label>
+              <input type="text" name="prodes" class="form-control" required />
+            </div>
+            <div class="form-group">
+              <label>Valor R$</label>
+              <input type="number" name="provl" class="form-control" min="0" step="0.01" required />
+            </div>
+            <div class="form-group">
+              <label>Marca</label>
+              <select id="selectPainelMarca" class="form-control" required>
+                <option value="">Selecione a Marca</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Modelo</label>
+              <select id="selectPainelModelo" class="form-control" required>
+                <option value="">Selecione o Modelo</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Tipo</label>
+              <select id="selectPainelTipo" class="form-control" required>
+                <option value="">Selecione o Tipo</option>
+              </select>
+            </div>
+            <button type="submit" class="btn btn-success">Cadastrar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
 
     <script src="/config.js"></script>
     <script src="html/auth/js/painel.js"></script>

--- a/public/html/auth/js/painel.js
+++ b/public/html/auth/js/painel.js
@@ -389,12 +389,6 @@ function excluirProduto(codigo) {
   }
 }
 
-// Impede que o dropdown feche ao clicar em qualquer elemento dentro dele
-document.querySelectorAll(".dropdown-menu").forEach(function (menu) {
-  menu.addEventListener("click", function (e) {
-    e.stopPropagation();
-  });
-});
 
 // Carrega os totais de marcas, modelos, tipos e peças
 document.addEventListener("DOMContentLoaded", async () => {

--- a/test/painel.test.js
+++ b/test/painel.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('Painel modals', () => {
+  test('modals exist with forms', () => {
+    const html = fs.readFileSync(path.join(__dirname, '../public/html/auth/admin/html/painel.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const doc = dom.window.document;
+
+    expect(doc.querySelector('#modalMarca')).not.toBeNull();
+    expect(doc.querySelector('#modalModelo')).not.toBeNull();
+    expect(doc.querySelector('#modalTipo')).not.toBeNull();
+    expect(doc.querySelector('#modalPeca')).not.toBeNull();
+
+    expect(doc.querySelector('#modalMarca form#cadastrarPainelMarca')).not.toBeNull();
+    expect(doc.querySelector('#modalPeca form#cadastrarPainelPeca')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- overhaul admin Painel UI with Bootstrap modals for managing Marcas, Modelos, Tipos and Peças
- simplify painal script by removing dropdown logic
- add basic DOM test for new modals
- fix typo in README
- add jest and jsdom for testing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869dced3818832c8c4f871ca06b72b0