### PR TITLE
Centralize alert and search elements

### DIFF
--- a/public/css/style-main.css
+++ b/public/css/style-main.css
@@ -45,3 +45,11 @@ main {
 .slide-down {
     animation: slideDown 0.5s ease-out forwards;
 }
+
+#inicioCentral {
+    min-height: 100vh;
+}
+
+#pesquisa {
+    width: 100%;
+}

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -42,8 +42,9 @@
     </header>
 
     <main>
-        <div class="alert alert-dismissible fade show shadow p-3 m-2 bg-white rounded" id="tutorialAlert"
-                style="max-width: 800px; margin: auto; display: none;" role="alert">
+        <div id="inicioCentral" class="d-flex flex-column justify-content-center align-items-center w-100">
+            <div class="alert alert-dismissible fade show shadow p-3 m-2 bg-white rounded" id="tutorialAlert"
+                style="max-width: 800px; display: none;" role="alert">
                 <strong>Primeira vez utilizando nosso sitema de pedidos?</strong> Assista o tutorial caso tenha alguma
                 dificuldade.
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close" id="tutorialAlertClose">
@@ -52,12 +53,13 @@
                 <hr>
                 <p class="mb-0"><button type="button" class="btn btn-danger"> <i class="bi bi-youtube"> </i>Tutorial em
                         video </i></button></p>
-        </div>    
-        <div class="m-5">
-            <form class="form-inline my-2 my-lg-0 mb-2">
-                <label for="">Pesquisa Geral</label>
-                <input class="form-control m-2 mr-sm-2 " type="search" placeholder="Pesquisar"aria-label="Pesquisar" id="pesquisa">
-            </form>
+            </div>
+            <div class="m-5 w-100">
+                <form class="mb-2 w-100">
+                    <label for="pesquisa">Pesquisa Geral</label>
+                    <input class="form-control m-2 w-100" type="search" placeholder="Pesquisar" aria-label="Pesquisar" id="pesquisa">
+                </form>
+            </div>
         </div>
         <div id="cardsArea">
             <div class="container-float">


### PR DESCRIPTION
## Summary
- center tutorial alert and search form on the home page
- stretch the search input to full width

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef5dd8c8832caa0fb69e3c3763a7