### PR TITLE
Add color management in admin panel

### DIFF
--- a/public/html/auth/admin/html/painel.html
+++ b/public/html/auth/admin/html/painel.html
@@ -290,10 +290,66 @@
                         </button>
                       </form>
                     </div>
-                    <button
+                  <button
                       class="btn btn-outline-secondary btn-block mt-2"
                       type="button"
                       onclick="toggleTipos()"
+                    >
+                      Gerenciar
+                    </button>
+                  </div>
+                  <!-- Cor -->
+                  <div
+                    class="col-12 col-sm-6 col-md-3 mb-3 dropdown position-static"
+                  >
+                    <button
+                      class="btn btn-outline-primary btn-block dropdown-toggle"
+                      type="button"
+                      id="dropdownCor"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      Cadastrar Cor <i class="bi bi-plus-square"></i>
+                    </button>
+                    <div
+                      class="dropdown-menu p-3 w-100 mt-2"
+                      aria-labelledby="dropdownCor"
+                      style="min-width: 220px"
+                      onclick="event.stopPropagation();"
+                    >
+                      <form id="cadastrarPainelCor" class="form">
+                        <div class="form-group mb-2">
+                          <div class="custom-select-wrapper">
+                            <select
+                              id="corProduto"
+                              class="form-control custom-select"
+                              required
+                            >
+                              <option value="">Selecione o Produto</option>
+                            </select>
+                          </div>
+                        </div>
+                        <div class="form-group mb-2">
+                          <div class="custom-select-wrapper">
+                            <select
+                              id="corCor"
+                              class="form-control custom-select"
+                              required
+                            >
+                              <option value="">Selecione a Cor</option>
+                            </select>
+                          </div>
+                        </div>
+                        <button type="submit" class="btn btn-success btn-block">
+                          Cadastrar
+                        </button>
+                      </form>
+                    </div>
+                    <button
+                      class="btn btn-outline-secondary btn-block mt-2"
+                      type="button"
+                      onclick="toggleCores()"
                     >
                       Gerenciar
                     </button>
@@ -444,6 +500,27 @@
                       </tr>
                     </thead>
                     <tbody id="listaTipos"></tbody>
+                  </table>
+                </div>
+                <div
+                  id="areaCores"
+                  class="mt-3 management-area"
+                  style="display: none"
+                >
+                  <h5>Cores do Produto</h5>
+                  <div class="form-group">
+                    <select id="selectProdutoGerenciarCor" class="form-control">
+                      <option value="">Selecione o Produto</option>
+                    </select>
+                  </div>
+                  <table class="table table-sm">
+                    <thead>
+                      <tr>
+                        <th>Cor</th>
+                        <th>Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody id="listaCores"></tbody>
                   </table>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- extend painel to allow managing available colors on products
- add Cor dropdown with form and management table
- implement JS logic to create, edit and delete product colors via existing routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68780bb924dc832cb855cb34a85fb133