### PR TITLE
fix: ordenar modelos ignorando espaços

### DIFF
--- a/public/html/auth/js/modelo.js
+++ b/public/html/auth/js/modelo.js
@@ -10,9 +10,11 @@ document.addEventListener("DOMContentLoaded", function () {
       const corpoTabela = document.getElementById("corpoTabela");
       corpoTabela.innerHTML = ""; // Limpa o conteúdo atual da tabela
 
-        dados.sort((a, b) =>
-          a.moddes.localeCompare(b.moddes, undefined, { numeric: true })
-        );
+        dados.sort((a, b) => {
+          const nomeA = a.moddes.replace(/\s/g, "");
+          const nomeB = b.moddes.replace(/\s/g, "");
+          return nomeA.localeCompare(nomeB, "pt-BR", { numeric: true });
+        });
 
         dados.forEach((dado) => {
           const tr = document.createElement("tr");

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -64,9 +64,11 @@ inputPesquisa.addEventListener("input", function () {
       }
 
       corpoTabela.innerHTML = "";
-      filtrados.sort((a, b) =>
-        a.moddes.localeCompare(b.moddes, undefined, { numeric: true })
-      );
+      filtrados.sort((a, b) => {
+        const nomeA = a.moddes.replace(/\s/g, "");
+        const nomeB = b.moddes.replace(/\s/g, "");
+        return nomeA.localeCompare(nomeB, "pt-BR", { numeric: true });
+      });
       filtrados.forEach((modelo) => {
         const item = document.createElement("div");
         item.className = "cart-item";

--- a/public/js/modelo.js
+++ b/public/js/modelo.js
@@ -10,9 +10,11 @@ document.addEventListener("DOMContentLoaded", function () {
       const corpoTabela = document.getElementById("corpoTabela");
       corpoTabela.innerHTML = ""; // Limpa o conteúdo atual da tabela
 
-        dados.sort((a, b) =>
-          a.moddes.localeCompare(b.moddes, undefined, { numeric: true })
-        );
+        dados.sort((a, b) => {
+          const nomeA = a.moddes.replace(/\s/g, "");
+          const nomeB = b.moddes.replace(/\s/g, "");
+          return nomeA.localeCompare(nomeB, "pt-BR", { numeric: true });
+        });
 
         dados.forEach((dado) => {
           const tr = document.createElement("tr");


### PR DESCRIPTION
## Summary
- ordenar modelos ignorando espaços e com ordenação alfanumérica

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689df402c468832cbf25334029627d3e