### PR TITLE
feat: migrate to bootstrap 5 and add placeholders

### DIFF
--- a/public/html/auth/admin/html/painel.html
+++ b/public/html/auth/admin/html/painel.html
@@ -9,8 +9,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
   <!--links bootstrap-->
   <link rel="stylesheet" href="../css/style-painel.css">
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-    integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
     integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -21,22 +20,22 @@
 <body>
         <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm bg-white rounded">
             <a class="navbar-brand" href="index" id="nomeEmpresa" ><img src="/uploads/logo.jpg" width="30" height="30" alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item active">
-                        <a class="nav-link" href="index">Inicio<span class="sr-only">(Página atual)</span></a>
+                        <a class="nav-link" href="index">Inicio<span class="visually-hidden">(Página atual)</span></a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="painel">Acesso</a>
                     </li>
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             Conta
                         </a>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                             <a class="dropdown-item" href="perfil">Perfil</a>
                             <a class="dropdown-item" href="configuracoes">Configurações</a>
                             <div class="dropdown-divider"></div>
@@ -117,7 +116,7 @@
           <div class="m-2">
             <h5 class="font-weight-bold text-center">Marca</h5>
             <button class="btn btn-outline-info btn-block bi-plus-lg" type="button" id="dropdownMarca"
-              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Cadastrar Marca
             </button>
             <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownMarca" style="min-width: 220px"
@@ -141,7 +140,7 @@
           <div class="m-2">
             <h5 class="font-weight-bold text-center">Modelo</h5>
             <button class="btn btn-outline-info btn-block bi-plus-lg" type="button" id="dropdownModelo"
-              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Cadastrar Modelo
             </button>
             <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownModelo" style="min-width: 220px"
@@ -179,7 +178,7 @@
           <div class="m-2">
             <h5 class="font-weight-bold text-center">Tipo de Peça</h5>
             <button class="btn btn-outline-info btn-block bi-plus-lg" type="button" id="dropdownTipo"
-              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Cadastrar Tipo de Peça
             </button>
             <div class="dropdown-menu p-3 w-100 mt-5" aria-labelledby="dropdownTipo" style="min-width: 220px"
@@ -205,7 +204,7 @@
           <div class="m-2">
             <h5 class="font-weight-bold text-center">Cor</h5>
             <button class="btn btn-outline-info btn-block bi-plus-lg" type="button" id="dropdownCor"
-              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Cadastrar Cor
             </button>
             <div class="dropdown-menu p-3 w-100 mt-2" aria-labelledby="dropdownCor" style="min-width: 220px"
@@ -228,8 +227,8 @@
           <div class="m-2">
             <h5 class="font-weight-bold text-center">Peça</h5>
             <div class="dropdown">
-              <button class="btn btn-outline-info btn-block bi-plus-lg dropdown-toggle" type="button" id="dropdownPeca"
-                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button class="btn btn-outline-info btn-block bi-plus-lg dropdown-toggle" type="button" id="dropdownPeca"
+                  data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Cadastrar Peça
               </button>
             
@@ -371,7 +370,7 @@
           Tecnologia que transforma seu negócio.</a></div>
       <div class="d-flex gap-3 footer small">
         <a href="https://wa.me/5561981697924?text=Ol%C3%A1!%20Tenho%20interesse%20para%20marcar%20uma%20reuni%C3%A3o%20para%20entender%20mais%20sobre%20as%20solu%C3%A7%C3%B5es%20que%20voc%C3%AAs%20oferecem!%20"
-          target="_blank" class="badge badge-secondary m-1">Contato</a>
+          target="_blank" class="badge bg-secondary m-1">Contato</a>
       </div>
     </div>
   </footer>
@@ -380,15 +379,8 @@
   <script src="../js/nomeEmpresa.js"></script>
   <script src="html/auth/js/painel.js"></script>
   <script src="html/auth/js/logout.js"></script>
-  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-    crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-    integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-    crossorigin="anonymous"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-    integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-    crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>  
 </body>
 

--- a/public/html/auth/login.html
+++ b/public/html/auth/login.html
@@ -9,8 +9,7 @@
     <link rel="stylesheet" href="../css/style-main.css">
     <link rel="shortcut icon" href="/uploads/logo.jpg" type="image/x-icon">
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -109,10 +108,8 @@
 </script>
     <script src="/config.js"></script>
     <script src="../js/nomeEmpresa.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/html/auth/js/login.js"></script>
 </body>
 </html>

--- a/public/html/auth/perfil.html
+++ b/public/html/auth/perfil.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="/uploads/logo.jpg" type="image/x-icon">
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/style-main.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
     <style>
@@ -45,22 +45,22 @@
     <header>
         <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm bg-white rounded">
             <a class="navbar-brand" href="index" id="nomeEmpresa" ><img src="/uploads/logo.jpg" width="30" height="30" alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item active">
-                        <a class="nav-link" href="index">Inicio <span class="sr-only">(Página atual)</span></a>
+                        <a class="nav-link" href="index">Inicio <span class="visually-hidden">(Página atual)</span></a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="painel">Acesso</a>
                     </li>
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             Conta
                         </a>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                             <a class="dropdown-item" href="perfil">Perfil</a>
                             <a class="dropdown-item" href="configuracoes">Configurações</a>
                             <div class="dropdown-divider"></div>
@@ -98,8 +98,7 @@
     <script src="../js/nomeEmpresa.js"></script>
     <script src="/html/auth/js/perfil.js"></script>
     <script src="/html/auth/js/logout.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/public/html/carrinho.html
+++ b/public/html/carrinho.html
@@ -11,8 +11,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
     <!--links bootstrap-->
     <link rel="stylesheet" href="../css/style-main.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -23,14 +22,14 @@
         <nav class="navbar navbar-expand-lg navbar-light shadow-sm rounded fixed-top">
             <a class="navbar-brand" href="index" id="nomeEmpresa"><img src="/uploads/logo.jpg" width="30" height="30"
                     alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item active">
-                        <a class="nav-link" href="index">Inicio <span class="sr-only">(Página atual)</span></a>
+                        <a class="nav-link" href="index">Inicio <span class="visually-hidden">(Página atual)</span></a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link " href="painel">Acesso</a>
@@ -86,15 +85,8 @@
     </footer>
     </div>
     <script src="/config.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-        integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-        crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-        integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-        crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../js/carrinho.js"></script>
     <script src="../js/nomeEmpresa.js"></script>
 </body>

--- a/public/html/configuracoes.html
+++ b/public/html/configuracoes.html
@@ -9,8 +9,7 @@
     <link rel="shortcut icon" href="/uploads/logo.jpg" type="image/x-icon">
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/style.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -62,24 +61,24 @@
         <nav class="navbar navbar-expand-lg navbar-light shadow-sm rounded fixed-top">
             <a class="navbar-brand" href="index" id="nomeEmpresa"><img src="/uploads/logo.jpg" width="30" height="30"
                     alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item active">
-                        <a class="nav-link" href="index">Inicio <span class="sr-only">(Página atual)</span></a>
+                        <a class="nav-link" href="index">Inicio <span class="visually-hidden">(Página atual)</span></a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="painel">Acesso</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
-                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             Conta
                         </a>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                             <a class="dropdown-item" href="perfil">Perfil</a>
                             <a class="dropdown-item" href="configuracoes">Configurações</a>
                             <div class="dropdown-divider"></div>
@@ -133,7 +132,7 @@
                     Tecnologia que transforma seu negócio.</a></div>
             <div class="d-flex gap-3 footer small">
                 <a href="https://wa.me/5561981697924?text=Ol%C3%A1!%20Tenho%20interesse%20para%20marcar%20uma%20reuni%C3%A3o%20para%20entender%20mais%20sobre%20as%20solu%C3%A7%C3%B5es%20que%20voc%C3%AAs%20oferecem!%20"
-                    target="_blank" class="badge badge-secondary m-1">Contato</a>
+                    target="_blank" class="badge bg-secondary m-1">Contato</a>
             </div>
         </div>
     </footer>
@@ -141,15 +140,8 @@
     <script src="../js/configWhatsapp.js"></script>
     <script src="/html/auth/js/logout.js"></script>
     <script src="../js/nomeEmpresa.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-        integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-        crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-        integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-        crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -15,8 +15,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
     <!--links bootstrap-->
     <link rel="stylesheet" href="../css/style-main.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -30,14 +29,14 @@
         <nav class="navbar navbar-expand-lg navbar-light shadow-sm rounded fixed-top">
             <a class="navbar-brand" href="index" id="nomeEmpresa"><img src="/uploads/logo.jpg" width="30" height="30"
                     alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item active">
-                        <a class="nav-link" href="index">Inicio <span class="sr-only">(Página atual)</span></a>
+                        <a class="nav-link" href="index">Inicio <span class="visually-hidden">(Página atual)</span></a>
                     </li>
 
                     <li class="nav-item">
@@ -56,9 +55,7 @@
                     style="max-width: 800px; margin: auto; display: none;" role="alert">
                     <strong>Primeira vez utilizando nosso sistema de pedidos?</strong> Assista o tutorial caso tenha alguma
                     dificuldade.
-                    <button type="button" class="close" data-dismiss="alert" aria-label="Close" id="tutorialAlertClose">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" id="tutorialAlertClose"></button>
                     <hr>
                     <p class="mb-0"><button type="button" class="btn btn-danger"> <i class="bi bi-youtube"> </i>Tutorial em
                             video </i></button></p>
@@ -83,7 +80,10 @@
                 </div>
                 <div class="container">
                     <div id="marcaTitulo">
-                        <!--Conteudo inserido via js marcas cadastradas-->
+                        <div id="marcaPlaceholder" class="placeholder-glow">
+                            <span class="placeholder col-12 mb-2"></span>
+                            <span class="placeholder col-8"></span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -113,15 +113,13 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="cartModalLabel">Itens no Carrinho</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="cartItems">
                     <!-- Itens do carrinho serão inseridos aqui via JS -->
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
                 </div>
             </div>
         </div>
@@ -173,15 +171,8 @@
     <script src="../js/nomeEmpresa.js"></script>
     <script src="/config.js"></script>
     <script src="../js/index.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-        integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-        crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-        integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-        crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/public/html/lista-pecas.html
+++ b/public/html/lista-pecas.html
@@ -12,8 +12,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
     <!--links bootstrap-->
     <link rel="stylesheet" href="../css/style-main.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -25,7 +24,7 @@
         <nav class="navbar navbar-expand-lg navbar-light shadow-sm rounded fixed-top">
             <a class="navbar-brand" href="index" id="nomeEmpresa"><img src="/uploads/logo.jpg" width="30" height="30"
                     alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -121,15 +120,13 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="cartModalLabel">Itens no Carrinho</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="cartItems">
                     <!-- Itens do carrinho serão inseridos aqui via JS -->
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
                 </div>
             </div>
         </div>
@@ -137,15 +134,8 @@
     <script src="/config.js"></script>
     <script src="../js/nomeEmpresa.js"></script>
     <script src="../js/lista-pecas.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-        integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-        crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-        integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-        crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/public/html/modelo.html
+++ b/public/html/modelo.html
@@ -13,8 +13,7 @@
   <!--links bootstrap-->
 
   <link rel="stylesheet" href="../css/style-main.css" />
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-    integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
     integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous" />
@@ -25,14 +24,14 @@
     <nav class="navbar navbar-expand-lg navbar-light shadow-sm rounded fixed-top">
       <a class="navbar-brand" href="index" id="nomeEmpresa"><img src="/uploads/logo.jpg" width="30" height="30"
           alt="" /></a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
         aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
           <li class="nav-item active">
-            <a class="nav-link" href="index">Inicio <span class="sr-only">(Página atual)</span></a>
+            <a class="nav-link" href="index">Inicio <span class="visually-hidden">(Página atual)</span></a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="painel">Acesso</a>
@@ -109,15 +108,13 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="cartModalLabel">Itens no Carrinho</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
-            <span aria-hidden="true">&times;</span>
-          </button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
         </div>
         <div class="modal-body" id="cartItems">
           <!-- Itens do carrinho serão inseridos aqui via JS -->
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
             Fechar
           </button>
         </div>
@@ -126,15 +123,8 @@
   </div>
   <script src="/config.js"></script>
   <script src="../js/nomeEmpresa.js"></script>
-  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-    crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-    integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-    crossorigin="anonymous"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-    integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-    crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../js/modelo.js"></script>
 </body>
 

--- a/public/html/pecas.html
+++ b/public/html/pecas.html
@@ -12,8 +12,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/uploads/apple-touch-icon.png">
     <!--links bootstrap-->
     <link rel="stylesheet" href="../css/style-main.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
         integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
@@ -24,7 +23,7 @@
         <nav class="navbar navbar-expand-lg navbar-light shadow-sm rounded fixed-top">
             <a class="navbar-brand" href="index" id="nomeEmpresa"><img src="/uploads/logo.jpg" width="30" height="30"
                     alt=""></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Alterna navegação">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -106,15 +105,13 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="cartModalLabel">Itens no Carrinho</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="cartItems">
                     <!-- Itens do carrinho serão inseridos aqui via JS -->
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
                 </div>
             </div>
         </div>
@@ -122,15 +119,8 @@
     <script src="/config.js"></script>
     <script src="../js/pecas.js"></script>
     <script src="../js/nomeEmpresa.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-        integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
-        crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
-        integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-        crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/public/html/register/registro.html
+++ b/public/html/register/registro.html
@@ -1,4 +1,3 @@
-<!-- crie uma pagina de login com o nome JP Peças -->
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
@@ -6,11 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title id="title">S/N</title>
     <link rel="stylesheet" href="../css/style-main.css">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
-        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
-        integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <style>
         body {
             background-color: #f8f9fa;
@@ -68,10 +65,7 @@
             <button type="submit" class="btn btn-primary">Entrar</button>
         </form>
     </div>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-    
-
-        
-        
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/public/js/carrinho-popup.js
+++ b/public/js/carrinho-popup.js
@@ -1,4 +1,7 @@
 // Função para atualizar o ícone do carrinho (exibe badge com quantidade de itens)
+const cartModalEl = document.getElementById("cartModal");
+const cartModal = cartModalEl ? new bootstrap.Modal(cartModalEl) : null;
+
 function atualizarIconeCarrinho() {
   const cart = JSON.parse(localStorage.getItem("cart") || "[]");
   let badge = document.getElementById("cartBadge");
@@ -14,7 +17,7 @@ function atualizarIconeCarrinho() {
   if (!badge) {
     badge = document.createElement("span");
     badge.id = "cartBadge";
-    badge.className = "badge badge-danger";
+    badge.className = "badge bg-danger";
     badge.style.position = "absolute";
     badge.style.left = "0";
     badge.style.bottom = "0";
@@ -67,7 +70,7 @@ function mostrarPopupAdicionado() {
 }
 
 document.getElementById("openCartModal").addEventListener("click", function () {
-  $("#cartModal").modal("show");
+  if (cartModal) cartModal.show();
   // Exemplo: carregar itens do carrinho (ajuste conforme sua lógica)
   const cart = JSON.parse(localStorage.getItem("cart") || "[]");
   const cartItemsDiv = document.getElementById("cartItems");
@@ -82,7 +85,7 @@ document.getElementById("openCartModal").addEventListener("click", function () {
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <span>${item.nome}</span>
           <span>
-            <span class="badge badge-primary badge-pill mr-2">${item.qt}</span>
+            <span class="badge bg-primary rounded-pill mr-2">${item.qt}</span>
             <button class="btn btn-danger btn-sm" onclick="removerItemCarrinho(${idx})">&times;</button>
           </span>
         </li>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -50,6 +50,9 @@ const tabelaArea = document.getElementById("tabelaArea");
 const cardsArea = document.getElementById("cardsArea");
 const corpoTabela = document.getElementById("corpoTabela");
 
+const cartModalEl = document.getElementById("cartModal");
+const cartModal = cartModalEl ? new bootstrap.Modal(cartModalEl) : null;
+
 let usuarioLogado = false;
 
 async function verificarLogin() {
@@ -202,7 +205,7 @@ function atualizarIconeCarrinho() {
   if (!badge) {
     badge = document.createElement("span");
     badge.id = "cartBadge";
-    badge.className = "badge badge-danger";
+    badge.className = "badge bg-danger";
     badge.style.position = "absolute";
     badge.style.left = "0";
     badge.style.bottom = "0";
@@ -255,7 +258,7 @@ function mostrarPopupAdicionado() {
 }
 
 document.getElementById("openCartModal").addEventListener("click", function () {
-  $("#cartModal").modal("show");
+  if (cartModal) cartModal.show();
   // Exemplo: carregar itens do carrinho (ajuste conforme sua lógica)
   const cart = JSON.parse(localStorage.getItem("cart") || "[]");
   const cartItemsDiv = document.getElementById("cartItems");
@@ -272,7 +275,7 @@ document.getElementById("openCartModal").addEventListener("click", function () {
             item.preco ? Number(item.preco).toFixed(2) : "0.00"
           })</small></span>
           <span>
-            <span class="badge badge-primary badge-pill mr-2">${item.qt}</span>
+            <span class="badge bg-primary rounded-pill mr-2">${item.qt}</span>
             <button class="btn btn-danger btn-sm" onclick="removerItemCarrinho(${idx})">&times;</button>
           </span>
         </li>
@@ -308,7 +311,8 @@ document.getElementById("openCartModal").addEventListener("click", function () {
         return; // Don't proceed if cart is empty
       }
       // Explicitly hide the modal before navigating
-      $("#cartModal").modal("hide");
+      const modalInstance = bootstrap.Modal.getInstance(cartModalEl);
+      modalInstance && modalInstance.hide();
       // Allow default navigation by not calling e.preventDefault() when cart is not empty
     };
 

--- a/public/js/lista-pecas.js
+++ b/public/js/lista-pecas.js
@@ -4,6 +4,9 @@ const id = params.get("id");
 const modelo = params.get("modelo");
 const marcascod = params.get("marcascod");
 
+const cartModalEl = document.getElementById("cartModal");
+const cartModal = cartModalEl ? new bootstrap.Modal(cartModalEl) : null;
+
 //Busca o nome do modelo pelo id usando fetch e exibe no elemento com id 'modeloTitulo'
 fetch(`${BASE_URL}/mod/${modelo}`)
   .then((res) => res.json())
@@ -101,7 +104,7 @@ function atualizarIconeCarrinho() {
   if (!badge) {
     badge = document.createElement("span");
     badge.id = "cartBadge";
-    badge.className = "badge badge-danger";
+    badge.className = "badge bg-danger";
     badge.style.position = "absolute";
     badge.style.left = "0";
     badge.style.bottom = "0";
@@ -154,7 +157,7 @@ function mostrarPopupAdicionado() {
 }
 
 document.getElementById("openCartModal").addEventListener("click", function () {
-  $("#cartModal").modal("show");
+  if (cartModal) cartModal.show();
   // Exemplo: carregar itens do carrinho (ajuste conforme sua lógica)
   const cart = JSON.parse(localStorage.getItem("cart") || "[]");
   const cartItemsDiv = document.getElementById("cartItems");
@@ -171,7 +174,7 @@ document.getElementById("openCartModal").addEventListener("click", function () {
             item.preco ? Number(item.preco).toFixed(2) : "0.00"
           })</small></span>
           <span>
-            <span class="badge badge-primary badge-pill mr-2">${item.qt}</span>
+            <span class="badge bg-primary rounded-pill mr-2">${item.qt}</span>
             <button class="btn btn-danger btn-sm" onclick="removerItemCarrinho(${idx})">&times;</button>
           </span>
         </li>
@@ -207,7 +210,8 @@ document.getElementById("openCartModal").addEventListener("click", function () {
         return; // Don't proceed if cart is empty
       }
       // Explicitly hide the modal before navigating
-      $("#cartModal").modal("hide");
+      const modalInstance = bootstrap.Modal.getInstance(cartModalEl);
+      modalInstance && modalInstance.hide();
       // Allow default navigation by not calling e.preventDefault() when cart is not empty
     };
 

--- a/public/js/modelo.js
+++ b/public/js/modelo.js
@@ -2,6 +2,9 @@ const params = new URLSearchParams(window.location.search);
 const id = params.get("id");
 const marcascod = params.get("marcascod");
 
+const cartModalEl = document.getElementById("cartModal");
+const cartModal = cartModalEl ? new bootstrap.Modal(cartModalEl) : null;
+
 //popular table com os dados do modelo
 document.addEventListener("DOMContentLoaded", function () {
   fetch(`${BASE_URL}/modelo/${id}`)
@@ -65,7 +68,7 @@ function atualizarIconeCarrinho() {
   if (!badge) {
     badge = document.createElement("span");
     badge.id = "cartBadge";
-    badge.className = "badge badge-danger";
+    badge.className = "badge bg-danger";
     badge.style.position = "absolute";
     badge.style.left = "0";
     badge.style.bottom = "0";
@@ -118,7 +121,7 @@ function mostrarPopupAdicionado() {
 }
 
 document.getElementById("openCartModal").addEventListener("click", function () {
-  $("#cartModal").modal("show");
+  if (cartModal) cartModal.show();
   // Exemplo: carregar itens do carrinho (ajuste conforme sua lógica)
   const cart = JSON.parse(localStorage.getItem("cart") || "[]");
   const cartItemsDiv = document.getElementById("cartItems");
@@ -135,7 +138,7 @@ document.getElementById("openCartModal").addEventListener("click", function () {
             item.preco ? Number(item.preco).toFixed(2) : "0.00"
           })</small></span>
           <span>
-            <span class="badge badge-primary badge-pill mr-2">${item.qt}</span>
+            <span class="badge bg-primary rounded-pill mr-2">${item.qt}</span>
             <button class="btn btn-danger btn-sm" onclick="removerItemCarrinho(${idx})">&times;</button>
           </span>
         </li>
@@ -171,7 +174,8 @@ document.getElementById("openCartModal").addEventListener("click", function () {
         return;
       }
       // Explicitly hide the modal before navigating
-      $("#cartModal").modal("hide");
+      const modalInstance = bootstrap.Modal.getInstance(cartModalEl);
+      modalInstance && modalInstance.hide();
     };
 
     cartModalFooter.appendChild(goToCartBtn);

--- a/public/js/pecas.js
+++ b/public/js/pecas.js
@@ -4,6 +4,9 @@ const id = params.get("id");
 const marcascod = params.get("marcascod");
 const modeloscod = params.get("modeloscod");
 
+const cartModalEl = document.getElementById("cartModal");
+const cartModal = cartModalEl ? new bootstrap.Modal(cartModalEl) : null;
+
 //Busca o nome do modelo pelo id usando fetch e exibe no elemento com id 'modeloTitulo'
   fetch(`${BASE_URL}/mod/${id}`)
   .then((res) => res.json())
@@ -70,7 +73,7 @@ function atualizarIconeCarrinho() {
   if (!badge) {
     badge = document.createElement("span");
     badge.id = "cartBadge";
-    badge.className = "badge badge-danger";
+    badge.className = "badge bg-danger";
     badge.style.position = "absolute";
     badge.style.left = "0";
     badge.style.bottom = "0";
@@ -123,7 +126,7 @@ function mostrarPopupAdicionado() {
 }
 
 document.getElementById("openCartModal").addEventListener("click", function () {
-  $("#cartModal").modal("show");
+  if (cartModal) cartModal.show();
   // Exemplo: carregar itens do carrinho (ajuste conforme sua lógica)
   const cart = JSON.parse(localStorage.getItem("cart") || "[]");
   const cartItemsDiv = document.getElementById("cartItems");
@@ -140,7 +143,7 @@ document.getElementById("openCartModal").addEventListener("click", function () {
             item.preco ? Number(item.preco).toFixed(2) : "0.00"
           })</small></span>
           <span>
-            <span class="badge badge-primary badge-pill mr-2">${item.qt}</span>
+            <span class="badge bg-primary rounded-pill mr-2">${item.qt}</span>
             <button class="btn btn-danger btn-sm" onclick="removerItemCarrinho(${idx})">&times;</button>
           </span>
         </li>
@@ -176,7 +179,8 @@ document.getElementById("openCartModal").addEventListener("click", function () {
         return; // Don't proceed if cart is empty
       }
       // Explicitly hide the modal before navigating
-      $("#cartModal").modal("hide");
+      const modalInstance = bootstrap.Modal.getInstance(cartModalEl);
+      modalInstance && modalInstance.hide();
       // Allow default navigation by not calling e.preventDefault() when cart is not empty
     };
 


### PR DESCRIPTION
## Summary
- update layout files to Bootstrap 5 and modern attributes
- add loading placeholder component on the home page
- use Bootstrap 5 JS APIs and new badge styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c58fd2a3cc832c8ec2a15fdd91870d