### PR TITLE
📌 Ajuste na ordenação do relatório de peças cadastradas

### DIFF
--- a/src/controllers/relatoriosController.js
+++ b/src/controllers/relatoriosController.js
@@ -352,7 +352,7 @@ exports.getPecasCadastradasPDF = async (req, res) => {
     doc.moveDown(0.5);
 
     // Cabeçalho da tabela
-    const colX = { num: 40, marca: 65, modelo: 165, tipo: 255, peca: 325, preco: 430, custo: 480, estoque: 535 };
+    const colX = { num: 40, marca: 65, modelo: 165, tipo: 255, peca: 325, preco: 475 };
     const ROW_PADDING_Y = 3;
 
     function drawTableHeader(d, y) {
@@ -363,10 +363,8 @@ exports.getPecasCadastradasPDF = async (req, res) => {
       d.text("Marca", colX.marca, y, { width: 95 });
       d.text("Modelo", colX.modelo, y, { width: 85 });
       d.text("Tipo", colX.tipo, y, { width: 65 });
-      d.text("Peça", colX.peca, y, { width: 100 });
-      d.text("Preço", colX.preco, y, { width: 45 });
-      d.text("Custo", colX.custo, y, { width: 45 });
-      d.text("Estoque", colX.estoque, y, { width: 45 });
+      d.text("Peça", colX.peca, y, { width: 145 });
+      d.text("Preço", colX.preco, y, { width: 80 });
       d.moveDown(0.8);
       d.font("Helvetica").fontSize(7);
     }
@@ -376,7 +374,6 @@ exports.getPecasCadastradasPDF = async (req, res) => {
     let rowNum = 1;
     for (const row of data) {
       const precoFmt = Number(row.preco).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
-      const custoFmt = Number(row.custo).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
       // Calculate dynamic row height so wrapped text never overlaps the next row
       const rowHeight = Math.max(
@@ -384,10 +381,8 @@ exports.getPecasCadastradasPDF = async (req, res) => {
         doc.heightOfString(String(row.marca || "-"), { width: 95 }),
         doc.heightOfString(String(row.modelo || "-"), { width: 85 }),
         doc.heightOfString(String(row.tipo || "-"), { width: 65 }),
-        doc.heightOfString(String(row.peca || "-"), { width: 100 }),
-        doc.heightOfString(precoFmt, { width: 45 }),
-        doc.heightOfString(custoFmt, { width: 45 }),
-        doc.heightOfString(String(row.estoque ?? 0), { width: 45 }),
+        doc.heightOfString(String(row.peca || "-"), { width: 145 }),
+        doc.heightOfString(precoFmt, { width: 80 }),
       );
 
       if (doc.y + rowHeight > PDF_PAGE_BREAK_Y) {
@@ -400,10 +395,8 @@ exports.getPecasCadastradasPDF = async (req, res) => {
       doc.text(String(row.marca || "-"), colX.marca, y, { width: 95 });
       doc.text(String(row.modelo || "-"), colX.modelo, y, { width: 85 });
       doc.text(String(row.tipo || "-"), colX.tipo, y, { width: 65 });
-      doc.text(String(row.peca || "-"), colX.peca, y, { width: 100 });
-      doc.text(precoFmt, colX.preco, y, { width: 45, align: "right" });
-      doc.text(custoFmt, colX.custo, y, { width: 45, align: "right" });
-      doc.text(String(row.estoque ?? 0), colX.estoque, y, { width: 45, align: "center" });
+      doc.text(String(row.peca || "-"), colX.peca, y, { width: 145 });
+      doc.text(precoFmt, colX.preco, y, { width: 80, align: "right" });
 
       // Advance by the tallest cell so no row ever overlaps the next
       doc.y = y + rowHeight + ROW_PADDING_Y;

--- a/src/models/relatoriosModels.js
+++ b/src/models/relatoriosModels.js
@@ -161,11 +161,7 @@ async function getPecasCadastradas(filters = {}) {
     LEFT JOIN modelo ON modelo.modcod = pro.promodcod
     LEFT JOIN tipo ON tipo.tipocod = pro.protipocod
     WHERE ${whereClause}
-    ORDER BY
-      pro.prodes,
-      marcas.marcasdes,
-      COALESCE(modelo.moddes, ''),
-      pro.procod
+    ORDER BY marcas.marcasdes
   `;
 
   const result = await pool.query(query, params);

--- a/src/models/relatoriosModels.js
+++ b/src/models/relatoriosModels.js
@@ -155,15 +155,17 @@ async function getPecasCadastradas(filters = {}) {
       modelo.moddes as modelo,
       tipo.tipodes as tipo,
       COALESCE(pro.provl, 0) as preco,
-      COALESCE(pro.procusto, 0) as custo,
-      COALESCE(pro.proqtde, 0) as estoque,
       pro.prosemest
     FROM pro
     JOIN marcas ON marcas.marcascod = pro.promarcascod
     LEFT JOIN modelo ON modelo.modcod = pro.promodcod
     LEFT JOIN tipo ON tipo.tipocod = pro.protipocod
     WHERE ${whereClause}
-    ORDER BY marcas.marcasdes, modelo.moddes, pro.prodes
+    ORDER BY
+      LOWER(TRIM(pro.prodes)),
+      LOWER(TRIM(marcas.marcasdes)),
+      LOWER(TRIM(COALESCE(modelo.moddes, ''))),
+      pro.procod
   `;
 
   const result = await pool.query(query, params);

--- a/src/models/relatoriosModels.js
+++ b/src/models/relatoriosModels.js
@@ -162,9 +162,9 @@ async function getPecasCadastradas(filters = {}) {
     LEFT JOIN tipo ON tipo.tipocod = pro.protipocod
     WHERE ${whereClause}
     ORDER BY
-      LOWER(TRIM(pro.prodes)),
-      LOWER(TRIM(marcas.marcasdes)),
-      LOWER(TRIM(COALESCE(modelo.moddes, ''))),
+      pro.prodes,
+      marcas.marcasdes,
+      COALESCE(modelo.moddes, ''),
       pro.procod
   `;
 

--- a/tests/relatoriosPecasCadastradas.test.js
+++ b/tests/relatoriosPecasCadastradas.test.js
@@ -1,0 +1,213 @@
+const assert = require("assert");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..");
+const dbModulePath = path.join(repoRoot, "src/config/db.js");
+const modelModulePath = path.join(repoRoot, "src/models/relatoriosModels.js");
+const controllerModulePath = path.join(
+  repoRoot,
+  "src/controllers/relatoriosController.js",
+);
+const pdfkitModulePath = require.resolve("pdfkit");
+
+async function testGetPecasCadastradasQuery() {
+  delete require.cache[modelModulePath];
+
+  const pool = require(dbModulePath);
+  const originalQuery = pool.query;
+  let capturedQuery;
+  let capturedParams;
+
+  pool.query = async (query, params) => {
+    capturedQuery = query;
+    capturedParams = params;
+    return { rows: [] };
+  };
+
+  try {
+    const relatoriosModels = require(modelModulePath);
+    await relatoriosModels.getPecasCadastradas({
+      marca: 10,
+      modelo: 20,
+      peca: "Tela",
+      tipo: 30,
+    });
+  } finally {
+    pool.query = originalQuery;
+    delete require.cache[modelModulePath];
+  }
+
+  assert.ok(capturedQuery, "A consulta deve ser executada");
+  assert.ok(
+    !capturedQuery.includes("as custo"),
+    "A consulta não deve selecionar a coluna custo",
+  );
+  assert.ok(
+    !capturedQuery.includes("as estoque"),
+    "A consulta não deve selecionar a coluna estoque",
+  );
+  assert.ok(
+    capturedQuery.includes("ORDER BY\n      LOWER(TRIM(pro.prodes))"),
+    "A consulta deve ordenar alfabeticamente pela peça",
+  );
+  assert.deepStrictEqual(capturedParams, [10, 20, "%Tela%", 30]);
+}
+
+class FakePDFDocument {
+  constructor() {
+    FakePDFDocument.lastInstance = this;
+    this.y = 40;
+    this.page = { margins: { left: 40 } };
+    this.textCalls = [];
+  }
+
+  pipe() {
+    return this;
+  }
+
+  setHeader() {
+    return this;
+  }
+
+  fontSize() {
+    return this;
+  }
+
+  font() {
+    return this;
+  }
+
+  fill() {
+    return this;
+  }
+
+  fillColor() {
+    return this;
+  }
+
+  rect() {
+    return this;
+  }
+
+  moveDown(lines = 1) {
+    this.y += lines * 10;
+    return this;
+  }
+
+  addPage() {
+    this.y = 40;
+    return this;
+  }
+
+  heightOfString(value) {
+    return String(value).length > 20 ? 16 : 8;
+  }
+
+  text(value, x, y, options) {
+    this.textCalls.push({ value: String(value), x, y, options });
+    if (typeof y === "number") {
+      this.y = y;
+    }
+    return this;
+  }
+
+  end() {
+    return this;
+  }
+}
+
+async function testPecasCadastradasPdfLayout() {
+  const relatoriosModels = require(path.join(repoRoot, "src/models/relatoriosModels"));
+  const originalGetPecasCadastradas = relatoriosModels.getPecasCadastradas;
+  const originalPdfkitExport = require.cache[pdfkitModulePath]?.exports;
+
+  relatoriosModels.getPecasCadastradas = async () => [
+    {
+      procod: 1,
+      peca: "Bateria",
+      marca: "Marca A",
+      modelo: "Modelo X",
+      tipo: "Componente",
+      preco: 199.9,
+      prosemest: "N",
+    },
+  ];
+
+  require.cache[pdfkitModulePath] = {
+    id: pdfkitModulePath,
+    filename: pdfkitModulePath,
+    loaded: true,
+    exports: FakePDFDocument,
+  };
+
+  delete require.cache[controllerModulePath];
+  const relatoriosController = require(controllerModulePath);
+
+  const res = {
+    headers: {},
+    headersSent: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+
+  try {
+    await relatoriosController.getPecasCadastradasPDF({ query: {} }, res);
+  } finally {
+    relatoriosModels.getPecasCadastradas = originalGetPecasCadastradas;
+    if (originalPdfkitExport) {
+      require.cache[pdfkitModulePath] = {
+        ...require.cache[pdfkitModulePath],
+        exports: originalPdfkitExport,
+      };
+    } else {
+      delete require.cache[pdfkitModulePath];
+    }
+    delete require.cache[controllerModulePath];
+  }
+
+  const docInstance = FakePDFDocument.lastInstance;
+  const renderedTexts = docInstance.textCalls.map(({ value }) => value);
+
+  assert.ok(
+    renderedTexts.includes("Peças Cadastradas"),
+    "O PDF deve manter o título do relatório",
+  );
+  assert.ok(
+    renderedTexts.includes("Preço"),
+    "O PDF deve manter a coluna de preço",
+  );
+  assert.ok(
+    !renderedTexts.includes("Custo"),
+    "O PDF não deve renderizar a coluna custo",
+  );
+  assert.ok(
+    !renderedTexts.includes("Estoque"),
+    "O PDF não deve renderizar a coluna estoque",
+  );
+}
+
+async function run() {
+  FakePDFDocument.lastInstance = null;
+  try {
+    await testGetPecasCadastradasQuery();
+    await testPecasCadastradasPdfLayout();
+    console.log("✅ relatoriosPecasCadastradas.test.js passou");
+  } catch (error) {
+    console.error("❌ relatoriosPecasCadastradas.test.js falhou");
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    delete require.cache[pdfkitModulePath];
+  }
+}
+
+run();

--- a/tests/relatoriosPecasCadastradas.test.js
+++ b/tests/relatoriosPecasCadastradas.test.js
@@ -47,10 +47,8 @@ async function testGetPecasCadastradasQuery() {
     "A consulta não deve selecionar a coluna estoque",
   );
   assert.ok(
-    /ORDER BY\s+pro\.prodes,\s+marcas\.marcasdes,\s+COALESCE\(modelo\.moddes, ''\),\s+pro\.procod/.test(
-      capturedQuery,
-    ),
-    "A consulta deve ordenar alfabeticamente pela peça",
+    /ORDER BY\s+marcas\.marcasdes/.test(capturedQuery),
+    "A consulta deve ordenar apenas pela marca",
   );
   assert.deepStrictEqual(capturedParams, [10, 20, "%Tela%", 30]);
 }

--- a/tests/relatoriosPecasCadastradas.test.js
+++ b/tests/relatoriosPecasCadastradas.test.js
@@ -47,7 +47,9 @@ async function testGetPecasCadastradasQuery() {
     "A consulta não deve selecionar a coluna estoque",
   );
   assert.ok(
-    capturedQuery.includes("ORDER BY\n      LOWER(TRIM(pro.prodes))"),
+    /ORDER BY\s+pro\.prodes,\s+marcas\.marcasdes,\s+COALESCE\(modelo\.moddes, ''\),\s+pro\.procod/.test(
+      capturedQuery,
+    ),
     "A consulta deve ordenar alfabeticamente pela peça",
   );
   assert.deepStrictEqual(capturedParams, [10, 20, "%Tela%", 30]);


### PR DESCRIPTION

🎯 Objetivo

Melhorar a organização das informações exibidas no relatório de peças cadastradas, corrigindo a ordenação dos registros e padronizando a listagem por marca.

🧾 Detalhes
Corrigida a ordenação do relatório de peças cadastradas
Ajustado o critério de ordenação dos registros exibidos
Alterada a listagem para ordenar as peças exclusivamente por marca
Revisada a lógica de geração do relatório para garantir consistência na exibição
Aplicados refinamentos para melhorar a visualização e a consulta das informações

✅ Resultado Esperado
Relatório exibindo as peças em ordem consistente
Listagem organizada por marca
Maior facilidade para localizar peças cadastradas
Apresentação padronizada das informações no relatório
Melhor experiência de consulta para os usuários

👤 Contribuidor
heitorgb